### PR TITLE
Add choice for API terminology update and bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+1.6.0 - 2024-08-24
+
+- added: initial terms check for new grease pencil API (gpv2 -> gpv3) in Blender 4.3
+- changed: separate terms toggle for propeties to annotations
+- fixed: permission terminology in manifest
+
 1.5.0 - 2024-06-07
 
 - added: button to create manifest.toml text from bl_info in opened text file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+1.7.0 - 2024-09-07
+
+- added: button to directly write the `blender_manifest.toml` aside `__init__.py` (ask to overwrite if already exists)
+
 1.6.0 - 2024-08-24
 
 - added: initial terms check for new grease pencil API (gpv2 -> gpv3) in Blender 4.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+1.8.0 - 2024-10-06
+
+- added: terms for GPv2 to GPv3
+- added: checkbox for icon verification toggle
+- fixed: broken detection for invalid icon
+- changed: 2.7 term search disabled by default
+
 1.7.0 - 2024-09-07
 
 - added: button to directly write the `blender_manifest.toml` aside `__init__.py` (ask to overwrite if already exists)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Find it in the Text Editor Sidebar.
 
 In `Update Script` panel you will also find:
 - `Insert Classes` : Create a tuple listing *classes* names in current text at cursor position. 
-- `Convert bl_info to manifest` : Get infos from *bl_info* in current text and reformat for Blender 4.2+ Extensions info format. Text is added to clipboard, ready to paste in a `manifest.toml` file at the root of the addon.
+- `bl_info to manifest` : Get infos from *bl_info* in current text and reformat for Blender 4.2+ Extensions info format.  
+Text is added to clipboard, ready to paste in a `blender_manifest.toml` file at the root of the addon.  
+- `Create manifest file` : Directly write the `blender_manifest.toml` file on disk, in the same folder of the loaded text file (it will ask to overwrite if the manifest already exists)
 
 ## About
 

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 6, 0),
+    "version": (1, 7, 0),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 7, 2),
+    "version": (1, 8, 0),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 7, 0),
+    "version": (1, 7, 1),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 7, 1),
+    "version": (1, 7, 2),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,10 +36,10 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 5, 0),
+    "version": (1, 6, 0),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
-    "description": "Runs cehck on current document",
+    "description": "Runs check on current document for updates",
     "warning": "",
     "wiki_url": "",
     "category": "Text Editor",

--- a/create_manifest.py
+++ b/create_manifest.py
@@ -2,6 +2,8 @@
 
 import bpy
 import re
+
+from bpy.types import Context, OperatorProperties
 from .fn import current_text
 from pathlib import Path
 from time import strftime
@@ -105,8 +107,46 @@ def bl_dict_to_manifest(bl_dict):
 class TEXT_OT_convert_bl_info_to_manifest(bpy.types.Operator):
     bl_idname = "text.convert_bl_info_to_manifest"
     bl_label = "convert bl_info to manifest"
-    bl_description = "Convert bl_info to manifest.toml format and save to clipboard"
+    bl_description = "Convert bl_info to blender_manifest.toml format and save to clipboard or create file"
     bl_options = {"REGISTER", "INTERNAL"}
+
+    write_on_disk : bpy.props.BoolProperty(default=False, options={'SKIP_SAVE'})
+
+    @classmethod
+    def description(cls, context, properties):
+        if properties.write_on_disk:
+            return f"Convert bl_info and save into a blender_manifest.toml file\
+                \nCurrent file needs to be saved on disk"
+        else:
+            return f"Convert bl_info in current file to a manifest formatting and save to clipboard\
+                \nNeed to be placed in a file blender_manifest.toml"
+
+    def invoke(self, context, event):
+        if not context.area.spaces.active.text:
+            self.report({'ERROR'}, 'No text in area')
+            return {"CANCELLED"}
+
+        if not self.write_on_disk:
+            return self.execute(context)
+        
+        if not context.area.spaces.active.text.filepath:
+            self.report({'ERROR'}, 'Current text is not saved on disk')
+            return {"CANCELLED"}
+        
+        self.manifest_path = Path(context.area.spaces.active.text.filepath).parent / 'blender_manifest.toml'
+        if self.manifest_path.exists():
+            return context.window_manager.invoke_props_dialog(self, width=500)
+            
+        return self.execute(context)
+    
+    def draw(self, context):
+        layout=self.layout
+        # layout.use_property_split = True
+        col = layout.column()
+        col.label(text='"blender_manifest.toml" file already exists !')
+        col.label(text="Overwrite file ?")
+        col.separator()
+        col.label(text=str(self.manifest_path))
 
     def execute(self, context):
         text = current_text(context)
@@ -120,11 +160,16 @@ class TEXT_OT_convert_bl_info_to_manifest(bpy.types.Operator):
             return {'CANCELLED'}
 
         manifest_text = bl_dict_to_manifest(bl_dict)
-        print('--- text to use in manifest.toml in addon root folder ---')
+        print('--- text to use in blender_manifest.toml in addon root folder ---')
         print(manifest_text)
-        
-        bpy.context.window_manager.clipboard = manifest_text
-        self.report({'INFO'}, 'Text saved to cliboard, paste in a "manifest.toml" file')
+
+        if self.write_on_disk:
+            with self.manifest_path.open('w') as fd:
+                fd.write(manifest_text)
+            self.report({'INFO'}, f'manifest file written at: {self.manifest_path}')
+        else:
+            bpy.context.window_manager.clipboard = manifest_text
+            self.report({'INFO'}, 'Text saved to cliboard, paste in a "blender_manifest.toml" file')
         return {"FINISHED"}
 
 classes = (

--- a/create_manifest.py
+++ b/create_manifest.py
@@ -53,13 +53,16 @@ def bl_dict_to_manifest(bl_dict):
     text_list.append('type = "add-on"')
     
     text_list.append("""
-# Optional: add-ons can list which resources they will require:
+# Optional: add-ons can list which resources they will require and description:
 # * "files" (for access of any filesystem operations)
 # * "network" (for internet access)
 # * "clipboard" (to read and/or write the system clipboard)
 # * "camera" (to capture photos and videos)
 # * "microphone" (to capture audio)
 # permissions = ["files", "network"])
+# [permissions]
+# network = "Automatic download"
+# files = "Write json data"
 """)
 
     text_list.append(f'website = {bl_dict.get("doc_url")}')

--- a/terms.py
+++ b/terms.py
@@ -11,36 +11,15 @@
 # it will be use to search and 'sub' the whole match with the string passed as third
 # captured groups, ex: \g<1> ,can be used to transfer elements from matched string.
 
-TERMS = [
 
+## Default terms
+TERMS = [
     #("scene.object_bases", "view_layer.objects.active"),
     ("INFO_MT_", "TOPBAR_MT_"),
     #("bl_idname", "only needed for Operator"),
-    #("Property", ": (annotation)"),
-    (" = StringProperty(", ": StringProperty("),
-    (" = BoolProperty(", ": BoolProperty("),
-    (" = BoolVectorProperty(", ": BoolVectorProperty("),
-    (" = CollectionProperty(", ": CollectionProperty("),
-    (" = EnumProperty(", ": EnumProperty("),
-    (" = FloatProperty(", ": FloatProperty("),
-    (" = FloatVectorProperty(", ": FloatVectorProperty("),
-    (" = IntProperty(", ": IntProperty("),
-    (" = IntVectorProperty(", ": IntVectorProperty("),
-    (" = PointerProperty(", ": PointerProperty("),
-    (" = RemoveProperty(", ": RemoveProperty("),
-    (" = bpy.props.StringProperty(", ": bpy.props.StringProperty("),
-    (" = bpy.props.BoolProperty(", ": bpy.props.BoolProperty("),
-    (" = bpy.props.BoolVectorProperty(", ": bpy.props.BoolVectorProperty("),
-    (" = bpy.props.CollectionProperty(", ": bpy.props.CollectionProperty("),
-    (" = bpy.props.EnumProperty(", ": bpy.props.EnumProperty("),
-    (" = bpy.props.FloatProperty(", ": bpy.props.FloatProperty("),
-    (" = bpy.props.FloatVectorProperty(", ": bpy.props.FloatVectorProperty("),
-    (" = bpy.props.IntProperty(", ": bpy.props.IntProperty("),
-    (" = bpy.props.IntVectorProperty(", ": bpy.props.IntVectorProperty("),
-    (" = bpy.props.PointerProperty(", ": bpy.props.PointerProperty("),
-    (" = bpy.props.RemoveProperty(", ": bpy.props.RemoveProperty("),
+
     # ("Operator):", "UPPERCASE_OT_snake_case("),
-    ### test on OPS (!no good, need conditions to be usefull!)
+    ### Test on OPS (!no good, need conditions to be usefull!)
     # ('regex.sub',
     #     r"(?:class )?([a-z]*)_([a-z]*)?(\((?:bpy\.types\.)?Operator\):)",
     #     lambda m: r'{}_OT_{}{}'.format(m.group(1).upper(), m.group(2), m.group(3))),
@@ -48,12 +27,42 @@ TERMS = [
     # ("Panel):", "UPPERCASE_PT_snake_case("),
     # ("Menu):", "UPPERCASE_MT_snake_case("),
     # ("UIList):", "UPPERCASE_UL_snake_case("),
-    #    ("Operator", "_OT"),
-    #    ("Panel", "_PT"),
-    #    ("Menu", "_MT"),
-    #    ("UIList", "_UL"),
+    # ("Operator", "_OT"),
+    # ("Panel", "_PT"),
+    # ("Menu", "_MT"),
+    # ("UIList", "_UL"),
+]
 
-    ## Replace obsolete bgl in 3.4
+## Propeties to annotations instead of assignmet in 3.0+
+TERMS_ANNOTATIONS = [
+    #("Property", ": (annotation)"),
+    ("= StringProperty(", ": StringProperty("),
+    ("= BoolProperty(", ": BoolProperty("),
+    ("= BoolVectorProperty(", ": BoolVectorProperty("),
+    ("= CollectionProperty(", ": CollectionProperty("),
+    ("= EnumProperty(", ": EnumProperty("),
+    ("= FloatProperty(", ": FloatProperty("),
+    ("= FloatVectorProperty(", ": FloatVectorProperty("),
+    ("= IntProperty(", ": IntProperty("),
+    ("= IntVectorProperty(", ": IntVectorProperty("),
+    ("= PointerProperty(", ": PointerProperty("),
+    ("= RemoveProperty(", ": RemoveProperty("),
+    ("= bpy.props.StringProperty(", ": bpy.props.StringProperty("),
+    ("= bpy.props.BoolProperty(", ": bpy.props.BoolProperty("),
+    ("= bpy.props.BoolVectorProperty(", ": bpy.props.BoolVectorProperty("),
+    ("= bpy.props.CollectionProperty(", ": bpy.props.CollectionProperty("),
+    ("= bpy.props.EnumProperty(", ": bpy.props.EnumProperty("),
+    ("= bpy.props.FloatProperty(", ": bpy.props.FloatProperty("),
+    ("= bpy.props.FloatVectorProperty(", ": bpy.props.FloatVectorProperty("),
+    ("= bpy.props.IntProperty(", ": bpy.props.IntProperty("),
+    ("= bpy.props.IntVectorProperty(", ": bpy.props.IntVectorProperty("),
+    ("= bpy.props.PointerProperty(", ": bpy.props.PointerProperty("),
+    ("= bpy.props.RemoveProperty(", ": bpy.props.RemoveProperty("),
+]
+
+
+TERMS_GPU = [
+    ## Replace obsolete bgl in 3.4+
     ("import bgl", ""),
     ("bgl.glEnable(bgl.GL_BLEND)", "gpu.state.blend_set('ALPHA')"),
     ("bgl.glDisable(bgl.GL_BLEND)", "gpu.state.blend_set('NONE')"),
@@ -74,7 +83,6 @@ TERMS = [
     # point_size_set(size): Specify the diameter of rasterized points.
     ('regex.sub', r"bgl\.glPointSize\(([a-zA-Z0-9]+)\)", """gpu.state.program_point_size_set(False)
     gpu.state.point_size_set(\g<1>)"""),
-
 ]
 
 TERMS_27 = [
@@ -188,6 +196,24 @@ TERMS_27 = [
     ('regex.quoted', "LINK", "DOT"),  #removed
     ('regex.quoted', "ORTHO", "VIEW_ORTHO"),  #removed
 ]
+
+
+## Update from GPv2 to GPv3 API in Blender 4.3
+TERMS_GP3 = [
+    (".info", ".name"), # Layer name
+    ('regex.sub', r"\.co(?!\w)", ".position"),
+    (".grease_pencil_modifiers", ".modifiers"), # Layer name
+    ('regex.quoted', "GPENCIL", "GREASEPENCIL"), # Type
+    ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context
+    (".active_frame", ".current_frame()"),
+    (".strokes", ".drawing.strokes"),
+    (".use_cyclic", ".use_cyclic"),
+    ("_gpencil_", "_greasepencil_"),
+    ("strokes.new()", "-> drawing.add_curves()"),
+]
+    # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
+    ## All at once ?
+
 #terms = str(TERMS).split('\n')
 #for t in terms:
 #    print('("' + t + '", ' + '"foo"),')

--- a/terms.py
+++ b/terms.py
@@ -158,9 +158,8 @@ TERMS_27 = [
         bpy.utils.unregister_class(i)"""),
     ("register_module", "register_class"),
     
-    ## old icons
-    ('regex.quoted', "TOOLS", "UI"), 
-    # equivalent to # ('regex.sub', r"('|\")TOOLS(\1)", "\g<1>UI\g<2>"),
+    ## Old icons
+    ('regex.quoted', "TOOLS", "UI"), # regex.quoted -> equivalent to # ('regex.sub', r"('|\")TOOLS(\1)", "\g<1>UI\g<2>"),
     ('regex.quoted', "ZOOMIN", "ADD"),
     ('regex.quoted', "ZOOMOUT", "REMOVE"),
     ('regex.quoted', "NEW", "FILE_NEW"),
@@ -199,10 +198,17 @@ TERMS_27 = [
 
 
 ## Update from GPv2 to GPv3 API in Blender 4.3
+## Order of the terms is important
 TERMS_GP3 = [
     (".info", ".name"), # Layer name
     ('regex.sub', r"\.co(?!\w)", ".position"),
-    (".grease_pencil_modifiers", ".modifiers"), # Layer name
+
+    ("bpy.ops.gpencil.vertex_group_assign()", "bpy.ops.object.vertex_group_assign()"),
+    # ("regex.sub", r"bpy\.ops\.object\.mode_set\(mode=('|\")EDIT_GPENCIL(\1)\)", "bpy.ops.object.mode_set(mode=\g<1>EDIT\g<2>)"), # version to match both quotes (not super clear)
+    ("bpy.ops.object.mode_set(mode='EDIT_GPENCIL')", "bpy.ops.object.mode_set(mode='EDIT')"), # single quote version
+    ('bpy.ops.object.mode_set(mode="EDIT_GPENCIL")', 'bpy.ops.object.mode_set(mode="EDIT")'), # double quote version
+    ('.gpencil_modifier', '.modifier'),
+    (".grease_pencil_modifiers", ".modifiers"),
     ('regex.quoted', "GPENCIL", "GREASEPENCIL"), # Type
     ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context # (Carefull: object.mode_set is not the same name anymore !)
     ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
@@ -218,7 +224,11 @@ TERMS_GP3 = [
     # ("regex.sub", r".*(?:points|strokes).update\(\))", r"\1# \2"), # comment lines with points.update() or stroke.update()
     ("regex.sub", ".*points.update\(\)", ""), # no points update anymore, delete
     ("regex.sub", ".*strokes.update\(\)", ""), # no strokes update anymore, delete
-    # ("_gpencil_", "_greasepencil_"), # only for class names, toolsettings are still gpencil !
+
+    ("regex.sub", r"(bpy\.types\..*(?:M|P)T.*_)gpencil(_)", r"\g<1>greasepencil\g<2>"), # replace gpencil to greasepencil in bpy.types menu and panels
+    
+    # ("_gpencil_", "_greasepencil_"), # /!\ too generic for now: Only for class names, toolsettings are still gpencil ! 
+
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?

--- a/terms.py
+++ b/terms.py
@@ -204,19 +204,25 @@ TERMS_GP3 = [
     ('regex.sub', r"\.co(?!\w)", ".position"),
     (".grease_pencil_modifiers", ".modifiers"), # Layer name
     ('regex.quoted', "GPENCIL", "GREASEPENCIL"), # Type
-    ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context
+    ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context # (Carefull: object.mode_set is not the same name anymore !)
     ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
     ('regex.quoted', "SCULPT_GPENCIL", "SCULPT_GREASE_PENCIL"), # sculpt context
     ('regex.quoted', "WEIGHT_GPENCIL", "WEIGHT_GREASE_PENCIL"), # weight context
     ('regex.quoted', "GP_LATTICE", "'GREASE_PENCIL_LATTICE'"), # modifier
     (".active_frame", ".current_frame()"),
     (".strokes", ".drawing.strokes"),
-    (".use_cyclic", ".use_cyclic"),
-    ("_gpencil_", "_greasepencil_"), # only for class names, toolsettings are still gpencil !
+    (".use_cyclic", ".cyclic"),
     ("strokes.new()", "-> drawing.add_curves()"),
+    (".use_multiedit", "-> context.scene.tool_settings.use_grease_pencil_multi_frame_editing"), # Not on GP data anymore !
+    ("strokes.remove(", "-> drawing.remove_strokes(indices=(0,)) # stroke index list"), # list of stroke index to remove
+    # ("regex.sub", r".*(?:points|strokes).update\(\))", r"\1# \2"), # comment lines with points.update() or stroke.update()
+    ("regex.sub", ".*points.update\(\)", ""), # no points update anymore, delete
+    ("regex.sub", ".*strokes.update\(\)", ""), # no strokes update anymore, delete
+    # ("_gpencil_", "_greasepencil_"), # only for class names, toolsettings are still gpencil !
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?
+    ## TODO: add isinstance(*stroke*, bpy.types.GpencilStroke) equivalent
 
 #terms = str(TERMS).split('\n')
 #for t in terms:

--- a/terms.py
+++ b/terms.py
@@ -208,6 +208,7 @@ TERMS_GP3 = [
     ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
     ('regex.quoted', "SCULPT_GPENCIL", "SCULPT_GREASE_PENCIL"), # sculpt context
     ('regex.quoted', "WEIGHT_GPENCIL", "WEIGHT_GREASE_PENCIL"), # weight context
+    ('regex.quoted', "GP_LATTICE", "'GREASE_PENCIL_LATTICE'"), # modifier
     (".active_frame", ".current_frame()"),
     (".strokes", ".drawing.strokes"),
     (".use_cyclic", ".use_cyclic"),

--- a/terms.py
+++ b/terms.py
@@ -205,10 +205,13 @@ TERMS_GP3 = [
     (".grease_pencil_modifiers", ".modifiers"), # Layer name
     ('regex.quoted', "GPENCIL", "GREASEPENCIL"), # Type
     ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context
+    ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
+    ('regex.quoted', "SCULPT_GPENCIL", "SCULPT_GREASE_PENCIL"), # sculpt context
+    ('regex.quoted', "WEIGHT_GPENCIL", "WEIGHT_GREASE_PENCIL"), # weight context
     (".active_frame", ".current_frame()"),
     (".strokes", ".drawing.strokes"),
     (".use_cyclic", ".use_cyclic"),
-    ("_gpencil_", "_greasepencil_"),
+    ("_gpencil_", "_greasepencil_"), # only for class names, toolsettings are still gpencil !
     ("strokes.new()", "-> drawing.add_curves()"),
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),

--- a/ui.py
+++ b/ui.py
@@ -15,22 +15,30 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
         layout.operator("text.insert_classes")
         layout.operator("text.convert_bl_info_to_manifest", icon='COPYDOWN')
 
-        layout.prop(context.scene, 'check_27', text='Include Terms From Blender 2.7')
+        col = layout.column()
+        settings = context.scene.script_updater_props
+        col.label(text='Include Terms:')
+        col.prop(settings, 'check_27', text='From Blender 2.7')
+        col.prop(settings, 'check_annotation', text='Properties To Annotation')
+        col.prop(settings, 'check_gpv3', text='GPv2 to GPv3')
+        
         layout.operator("text.update_script_button")
         
-
+        # wm = bpy.context.window_manager
         if not hasattr(bpy.types.Scene, 'update_script'):
             return
-        if context.scene.update_script_name != bpy.context.space_data.text.filepath:
+        if context.scene.script_updater_props.script_name != bpy.context.space_data.text.filepath:
             return
 
         box = layout.box()
+        # items = wm.update_script
         items = context.scene.update_script
         for it in items:
-            cline = it[0]
-            cname = it[1]
-            cword = it[2]
-            csuggestion = it[3]
+            cline = it[0] # Line number
+            cname = it[1] # Original line
+            cword = it[2] # Matched words
+            csuggestion = it[3] # Replacement
+
             box = box.column(align=True)
             row = box.row(align=True)
             row.alignment = 'LEFT'

--- a/ui.py
+++ b/ui.py
@@ -24,6 +24,7 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
         col.prop(settings, 'check_27', text='From Blender 2.7')
         col.prop(settings, 'check_annotation', text='Properties To Annotation')
         col.prop(settings, 'check_gpv3', text='GPv2 to GPv3')
+        col.prop(settings, 'check_icons', text='Icon Names')
         
         layout.operator("text.update_script_button")
         

--- a/ui.py
+++ b/ui.py
@@ -13,7 +13,10 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         layout.operator("text.insert_classes")
-        layout.operator("text.convert_bl_info_to_manifest", icon='COPYDOWN')
+        row = layout.row(align=True)
+
+        row.operator("text.convert_bl_info_to_manifest", text='bl_info to manifest', icon='COPYDOWN')
+        row.operator("text.convert_bl_info_to_manifest", text='Create Manifest File', icon='FILE_TICK').write_on_disk = True
 
         col = layout.column()
         settings = context.scene.script_updater_props

--- a/update_check.py
+++ b/update_check.py
@@ -2,10 +2,29 @@ import re, bpy
 from bpy.props import IntProperty, StringProperty, BoolProperty
 
 from .fn import current_text
-from .terms import TERMS, TERMS_27
+from .terms import TERMS, TERMS_27, TERMS_ANNOTATIONS, TERMS_GP3
 
 
 def check_files(txt) -> list:
+    '''Return a list of lists of search-replace match in text:
+    [line number (int), original full line, matched string, replacement suggestion]
+    '''
+
+    settings = bpy.context.scene.script_updater_props
+
+    # Build Terms
+    term_list = []
+    
+    term_list += TERMS
+
+    if settings.check_27:
+        term_list += TERMS_27
+
+    if settings.check_annotation:
+        term_list += TERMS_ANNOTATIONS
+
+    if settings.check_gpv3:
+        term_list += TERMS_GP3
 
     suggestions = []
     txt = str(txt)
@@ -24,13 +43,6 @@ def check_files(txt) -> list:
             if icon not in current_bl_icons and icon != []:
                 suggestions.append([int(i), line, icon[0], 'Icon missing. Replace it.'])
                 # break
-            
-            # Check for Terms
-            if bpy.context.scene.check_27:
-                # add terms relative to upgrade from 2.7
-                term_list = TERMS + TERMS_27
-            else:
-                term_list = TERMS
 
             for t in term_list:
                 if t[0].startswith('regex.'):
@@ -46,13 +58,13 @@ def check_files(txt) -> list:
                     if not res:
                         continue
 
-                    print('pattern: ', pattern)
-                    print('repl: ', repl)
+                    # print('pattern: ', pattern) # Dbg
+                    # print('repl: ', repl) # Dbg
                     if t[0].split('.')[-1] in ('sub', 'quoted'):
                         string = res.group(0)
-                        print('string: ', string)
+                        # print('string: ', string) # Dbg
                         suggestion = re.sub(pattern, repl, string)
-                        print('suggestion: ', suggestion)
+                        # print('suggestion: ', suggestion) # Dbg
                         suggestions.append([int(i), line, string, suggestion])
                     
 
@@ -61,7 +73,6 @@ def check_files(txt) -> list:
                         #print("%4d" % i, line, '||', t[0], '-', t[1])
                         suggestions.append([int(i), line, t[0], t[1]])
                         break
-
     return suggestions
 
 
@@ -72,10 +83,18 @@ class TEXT_OT_update_script_button(bpy.types.Operator):
 
     def execute(self, context):
         filename = bpy.context.space_data.text.filepath
-        bpy.context.scene.update_script_name = filename
-        ## Create new attribute 
-        bpy.types.Scene.update_script = check_files(current_text(context))
+        bpy.context.scene.script_updater_props.script_name = filename
+        
+        ## Create new attribute
+        # wm = bpy.context.window_manager
+        # wm.update_script = check_files(current_text(context))
 
+        if hasattr(bpy.types.Scene, 'update_script'):
+            del bpy.types.Scene.update_script
+            # bpy.types.Scene.update_script.clear()
+        bpy.types.Scene.update_script = check_files(current_text(context))
+        print(len(context.scene.update_script))
+        # context.scene.update_script = check_files(current_text(context))
         return {'FINISHED'}
 
 
@@ -118,10 +137,18 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
     """Jump to line"""
     bl_idname = "text.update_script_jump"
     bl_label = "Update_script Jump"
+    bl_description = 'Click to set search replace on current word\
+    \nCtrl+Click for Direct replace'
 
-    line: IntProperty(default=0, options={'HIDDEN'})
-    cword: StringProperty(default="", options={'HIDDEN'})
-    csuggestion: StringProperty(default="", options={'HIDDEN'})
+    line : IntProperty(default=0, options={'HIDDEN'})
+    cword : StringProperty(default="", options={'HIDDEN'})
+    csuggestion : StringProperty(default="", options={'HIDDEN'})
+
+    replace : BoolProperty(default=False, options={'SKIP_SAVE'})
+
+    def invoke(self, context, event):
+        self.replace = event.ctrl
+        return self.execute(context)
 
     def execute(self, context):
         line = self.line
@@ -133,12 +160,32 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
             bpy.context.space_data.find_text = cword
             bpy.context.space_data.replace_text = csuggestion
             bpy.ops.text.find()
+            if self.replace:
+                bpy.ops.text.replace()
+                bpy.ops.text.jump(line=line)
         self.line = -1
 
         return {'FINISHED'}
 
 
+class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
+    check_27 : BoolProperty(
+        name='Include 2.7 Terms', default=True,
+        description='Search for terms specific to blender 2.7 version')
+    
+    check_annotation : BoolProperty(
+        name='Prop To Annotations', default=True,
+        description='Search for properties assignement to annotation (= replaced by : on properties since blender 2.8)')
+    
+    check_gpv3 : BoolProperty(
+        name='GPv2 to GPv3', default=True,
+        description='Grease pencil API from v2 to v3 (changed at Blender 4.3)')
+
+    script_name : bpy.props.StringProperty()
+
+
 classes = (
+    TEXT_PGT_script_update_checker_settings,
     TEXT_OT_update_script_jump,
     TEXT_OT_update_script_button,
     TEXT_OT_insert_classes_button,
@@ -146,24 +193,18 @@ classes = (
 
 
 def register():
-    bpy.types.Scene.check_27 = BoolProperty(
-        name='Include 2.7 Terms', default=True,
-        description='search for terms specific to blender 2.7 version')
-    
-    # bpy.types.Scene.update_script = bpy.props.StringProperty() # registered on the fly in operator
-    bpy.types.Scene.update_script_name = bpy.props.StringProperty()
     for cls in classes:
         bpy.utils.register_class(cls)
 
+    bpy.types.Scene.script_updater_props = bpy.props.PointerProperty(type = TEXT_PGT_script_update_checker_settings)
+
 
 def unregister():
-
     for cls in classes:
         bpy.utils.unregister_class(cls)
     
+    if hasattr(bpy.types.Scene, 'script_updater_props'):
+        del bpy.types.Scene.script_updater_props
+
     if hasattr(bpy.types.Scene, 'update_script'):
         del bpy.types.Scene.update_script
-
-    # if hasattr(bpy.types.Scene, 'update_script_name'):
-    del bpy.types.Scene.update_script_name
-    del bpy.types.Scene.check_27

--- a/update_check.py
+++ b/update_check.py
@@ -31,6 +31,12 @@ def check_files(txt) -> list:
     split_file = txt.split('\n')
 
     # Collect valid icon names
+    ## Using identifier
+    # current_bl_icons = [i.identifier
+    #     for i in bpy.types.UILayout.bl_rna.functions['prop'].parameters['icon'].enum_items
+    #     if i.identifier != 'NONE']
+
+    ## Using .keys()
     current_bl_icons = [
         i for i in bpy.types.UILayout.bl_rna.functions["prop"].parameters["icon"]
         .enum_items.keys() if i != 'NONE'
@@ -38,11 +44,12 @@ def check_files(txt) -> list:
 
     for i, line in enumerate(split_file, 1):
         if line != '':
-            # Check for removed icons
-            icon = re.findall(r'icon\s{,2}=\s{,2}(?:\'|\")([A-Z_]+)(?:\'|\")', line)
-            if icon not in current_bl_icons and icon != []:
-                suggestions.append([int(i), line, icon[0], 'Icon missing. Replace it.'])
-                # break
+            if settings.check_icons:
+                # Check for removed icons
+                icon_list = re.findall(r'icon\s{,2}=\s{,2}(?:\'|\")([A-Z_]+)(?:\'|\")', line)
+                if icon_list and icon_list[0] not in current_bl_icons:
+                    suggestions.append([int(i), line, icon_list[0], 'Icon missing. Replace it.'])
+                    # break
 
             for t in term_list:
                 if t[0].startswith('regex.'):
@@ -170,7 +177,7 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
 
 class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
     check_27 : BoolProperty(
-        name='Include 2.7 Terms', default=True,
+        name='Include 2.7 Terms', default=False,
         description='Search for terms specific to blender 2.7 version')
     
     check_annotation : BoolProperty(
@@ -180,6 +187,11 @@ class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
     check_gpv3 : BoolProperty(
         name='GPv2 to GPv3', default=True,
         description='Grease pencil API from v2 to v3 (changed at Blender 4.3)')
+    
+    check_icons : BoolProperty(
+        name='Icons Name', default=True,
+        description='Check icon name\
+            \n(Should use the targeted Blender version for the script!)')
 
     script_name : bpy.props.StringProperty()
 


### PR DESCRIPTION
Changelog since last PR:

1.8.0 - 2024-10-06

- added: terms for GPv2 to GPv3
- added: checkbox for icon verification toggle
- fixed: broken detection for invalid icon
- changed: 2.7 term search disabled by default

1.7.0 - 2024-09-07

- added: button to directly write the `blender_manifest.toml` aside `__init__.py` (ask to overwrite if already exists)

1.6.0 - 2024-08-24

- added: initial terms check for new grease pencil API (gpv2 -> gpv3) in Blender 4.3
- changed: separate terms toggle for properties to annotations
- fixed: permission terminology in manifest

@tin2tin Let me know if my somewhat randoms PRs bother you :)