### PR TITLE
Add autorefresh and undo push on replaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+1.9.0 - 2024-12-05
+
+- added: auto-refresh mode, refresh check after a replace. allowing to work way faster, alternating click and ctrl+click without moving mouse.
+- added: undo step push when replacing a term when using replace(safer, allow to ctrl+Z if it was not intended)
+- added: line number are now a button you can click on to directly jump and replace (same as Ctrl+Click on text)
+- added: feedback text when there are no match
+- added: Dynamic jump/replace operator descriptions + an _info note_ button to explain how to use on hover/click
+
 1.8.2 - 2024-10-11
 
 - added: GP v2->v3 modifier type strings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+1.8.2 - 2024-10-11
+
+- added: GP v2->v3 modifier type strings
+- fixed: some error in new GPv3 API propnames
+
 1.8.0 - 2024-10-06
 
 - added: terms for GPv2 to GPv3

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Changes and API equivalences are listed in the [official GP migration page](http
 The addons works well with the search & replace to update parts of yours script, but of course it does not cover all the things to change.
 
 Also, you might want to affect multiple files at once using an external IDE.  
-So here is a list of search and replaces _regexes_ + extra notes as a complement migration page.  
-It's still recommended to apply the replaces one by one to avoid false-positive matches.  
+So here is a list of search and replaces, _regexes_ and extra notes as a complement for the official migration page.  
+It's still recommended to apply the replaces one by one to avoid false-positive replace.  
 
 > Note: This is provided "as is", no one is responsible if there are error or if it breaks your script ;)
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,16 @@ Text is added to clipboard, ready to paste in a `blender_manifest.toml` file at 
 
 Following the full rewrite of Grease pencil shipped in Blender 4.3+, the API terms updater include search and replaces for Grease pencil V2 to V3.
  
-Changes and API equivalences are listed in the [official GP migration page](https://developer.blender.org/docs/release_notes/4.3/grease_pencil_migration/).  
+### Some links related to Grease pencil V3
 
+Changes and API equivalences are listed in the [official GP migration page](https://developer.blender.org/docs/release_notes/4.3/grease_pencil_migration/).
+
+The examples in [using attribute page](https://docs.blender.org/api/4.3/bpy.types.Attribute.html#using-attributes) are really useful now that Grease Pencil fully uses attributes (allowing use in geometry nodes)
+
+The [architecture internal attribute page](https://developer.blender.org/docs/features/grease_pencil/architecture/#internal-attributes) depicts the structure of Grease pencil V3
+
+
+## Extra migration helpers
 
 The addons works well with the search & replace to update parts of yours script, but of course it does not cover all the things to change.
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,12 @@ Check scripts for functions which needs to be updated to the latest Blender.
 
 Find it in the Text Editor Sidebar.
 
-# How
+## How
 
 1. Open the script in question in the Text Editor and execute the operator in the sidebar. 
 2. All items with issues will be listed in the sidebar. 
 3. Click on an issue to go to that line. 
 4. Fix the line.
-
 
 ## Addtional feature
 
@@ -21,7 +20,94 @@ In `Update Script` panel you will also find:
 Text is added to clipboard, ready to paste in a `blender_manifest.toml` file at the root of the addon.  
 - `Create manifest file` : Directly write the `blender_manifest.toml` file on disk, in the same folder of the loaded text file (it will ask to overwrite if the manifest already exists)
 
-## About
+## GPv2 to GPv3 update notes
+
+Following the full rewrite of Grease pencil shipped in Blender 4.3+, the API terms updater include search and replaces for Grease pencil V2 to V3.
+ 
+Changes and API equivalences are listed in the [official GP migration page](https://developer.blender.org/docs/release_notes/4.3/grease_pencil_migration/).  
+
+
+The addons works well with the search & replace to update parts of yours script, but of course it does not cover all the things to change.
+
+Also, you might want to affect multiple files at once using an external IDE.  
+So here is a list of search and replaces _regexes_ + extra notes as a complement migration page.  
+It's still recommended to apply the replaces one by one to avoid false-positive matches.  
+
+> Note: This is provided "as is", no one is responsible if there are error or if it breaks your script ;)
+
+### Search and replace
+
+|                 | Search                     | Replace            |
+| --------------- | -------------------------- | ------------------ |
+| layer name      | `.info`                    | `.name`            |
+| modifier access | `.grease_pencil_modifiers` | `.modifiers`       |
+| active frame    | `.active_frame`            | `.current_frame()` |
+
+#### Regex search and replace
+
+Those marked with `/!\` in _notes_ column must be handled with extra care
+
+> Before replacing _context modes_ below, first replace `mode_set` operator (if any) from `GPENCIL_EDIT` to `EDIT`.  
+> This will avoid replacing it by the `context_mode` name by mistake:
+> `bpy.ops.object.mode_set(mode='EDIT_GPENCIL')` > to > `bpy.ops.object.mode_set(mode='EDIT')`
+
+|                    | Search                                            | Replace                | Notes                                                            |
+| ------------------ | ------------------------------------------------- | ---------------------- | ---------------------------------------------------------------- |
+| GP type string     | `('\|")GPENCIL(\1)`                               | `$1GREASEPENCIL$1`     | quotes avoid matching `GPENCIL` within strings                   |
+| context modes      | `('\|")(PAINT\|EDIT\|SCULPT\|WEIGHT)_GPENCIL(\1)` | `$1$2_GREASE_PENCIL$1` | `/!\` ops `object.mode_set` use just "EDIT"                        |
+| position attribute | `\.co(?!\w)`                                      | `.position`            | `/!\` vertices and fcurvce points still use `.co`                |
+| drawing container  | `(?<!drawing)\.strokes`                           | `.drawing.strokes`     | Regex check if 'drawing' keyword is already there                |
+| obsolete update    | `.*(?:points\|strokes).update\(\))`               | `\1# \2`               | Comment point/stroke update(), empty the replace field to remove |
+
+
+#### Modifiers
+
+For most modifier type, just a prefix change, `GP_` becomes `GREASE_PENCIL_`. Here is a regex for those:
+
+search : `('\|")GP_(LATTICE|BUILD|NOISE|TIME|TEXTURE|DASH|ENVELOPE|LENGTH|MIRROR|MULTIPLY|OUTLINE|SIMPLIFY|SUBDIV|ARMATURE|HOOK|OFFSET|SMOOTH|COLOR|OPACITY|TINT|ARRAY)(\1)`  
+replace: `$1GP_$2$1`
+
+List of other modifier type with name changed:
+
+| Search                | Replace                                 |
+| --------------------- | --------------------------------------- |
+| `GP_WEIGHT_PROXIMITY` | `GREASE_PENCIL_VERTEX_WEIGHT_PROXIMITY` |
+| `GP_WEIGHT_ANGLE`     | `GREASE_PENCIL_VERTEX_WEIGHT_ANGLE`     |
+| `GP_LINEART`          | `LINEART`                               |
+| `GP_THICK`            | `GREASE_PENCIL_THICKNESS`               |
+
+> /!\ special case:  `SHRINKWRAP` becomes `GREASE_PENCIL_SHRINKWRAP` but in 4.2 the name was the same for other object type (not GP only), so cannot be batch replaced.
+
+#### Operators
+
+|                     | Blender 4.2                             | Blender 4.3                            |
+| ------------------- | --------------------------------------- | -------------------------------------- |
+| vertex group assign | `bpy.ops.gpencil.vertex_group_assign()` | `bpy.ops.object.vertex_group_assign()` |
+
+
+#### bpy.types
+
+| Blender 4.2                            | Blender 4.3                                      |
+| -------------------------------------- | ------------------------------------------------ |
+| `VIEW3D_MT_edit_gpencil_transform`     | `VIEW3D_MT_transform`                            |
+| `VIEW3D_MT_edit_gpencil_stroke`        | `VIEW3D_MT_edit_greasepencil_stroke`             |
+| `VIEW3D_MT_brush_gpencil_context_menu` | `VIEW3D_MT_brush_context_menu`                   |
+| `GPENCIL_MT_layer_context_menu`        | `GREASE_PENCIL_MT_grease_pencil_add_layer_extra` |
+| `GPENCIL_MT_cleanup`                   | `VIEW3D_MT_edit_greasepencil_cleanup`            |
+| `VIEW3D_MT_gpencil_edit_context_menu`  | `VIEW3D_MT_greasepencil_edit_context_menu`       |
+
+
+#### Replace with tweaks needed
+
+|                  | Search            | Replace                                                             | Notes                                                                |
+| ---------------- | ----------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| Multiframe  mode | `.use_multiedit`  | `context.scene.tool_settings.use_grease_pencil_multi_frame_editing` | Not stored on GP.data anymore, now a scene setting                   |
+| Remove Stroke    | `strokes.remove(` | `drawing.remove_strokes(indices=(0,))`                              | Not using a stroke object, but a list of stroke indices in drawing.  |
+| Add strokes      | `strokes.new()`   | `drawing.add_strokes([0])`                                          | int sequence: [2,4] will add one stroke with 2 points and one with 4 |
+
+
+
+## About Script Update Checker addon
 
 nBurn writes:
 "Add-on update helper script

--- a/__init__.py
+++ b/__init__.py
@@ -36,8 +36,8 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 8, 3),
-    "blender": (3, 3, 0),
+    "version": (1, 9, 0),
+    "blender": (4, 0, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",
     "warning": "",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 8, 1),
+    "version": (1, 8, 2),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 8, 2),
+    "version": (1, 8, 3),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/__init__.py
+++ b/__init__.py
@@ -36,7 +36,7 @@ this Software without prior written authorization.
 bl_info = {
     "name": "Script Update Checker",
     "author": "nBurn, tin2tin, Samuel Bernou",
-    "version": (1, 8, 0),
+    "version": (1, 8, 1),
     "blender": (3, 3, 0),
     "location": "Text Editor > Sidebar > Text > Update Script",
     "description": "Runs check on current document for updates",

--- a/terms.py
+++ b/terms.py
@@ -210,15 +210,15 @@ TERMS_GP3 = [
     ('.gpencil_modifier', '.modifier'),
     (".grease_pencil_modifiers", ".modifiers"),
     ('regex.quoted', "GPENCIL", "GREASEPENCIL"), # Type
-    ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context # (Carefull: object.mode_set is not the same name anymore !)
+    ('regex.quoted', "PAINT_GPENCIL", "PAINT_GREASE_PENCIL"), # paint context
     ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
     ('regex.quoted', "SCULPT_GPENCIL", "SCULPT_GREASE_PENCIL"), # sculpt context
     ('regex.quoted', "WEIGHT_GPENCIL", "WEIGHT_GREASE_PENCIL"), # weight context
     ('regex.quoted', "GP_LATTICE", "'GREASE_PENCIL_LATTICE'"), # modifier
-    (".active_frame", ".current_frame()"),
+    (".active_frame", ".current_frame([1])"), # sequence of int (number of points to add on each strokes)
     (".strokes", ".drawing.strokes"),
     (".use_cyclic", ".cyclic"),
-    ("strokes.new()", "-> drawing.add_curves()"),
+    ("strokes.new()", "-> drawing.add_strokes()"),
     (".use_multiedit", "-> context.scene.tool_settings.use_grease_pencil_multi_frame_editing"), # Not on GP data anymore !
     ("strokes.remove(", "-> drawing.remove_strokes(indices=(0,)) # stroke index list"), # list of stroke index to remove
     # ("regex.sub", r".*(?:points|strokes).update\(\))", r"\1# \2"), # comment lines with points.update() or stroke.update()

--- a/terms.py
+++ b/terms.py
@@ -231,7 +231,11 @@ TERMS_GP3 = [
     ('regex.quoted', "GP_WEIGHT_ANGLE", "GREASE_PENCIL_VERTEX_WEIGHT_ANGLE"),
     ('regex.quoted', "GP_LINEART", "LINEART"),
     ('regex.quoted', "GP_THICK", "GREASE_PENCIL_THICKNESS"),
-    # ('regex.quoted', "SHRINKWRAP", "GREASE_PENCIL_SHRINKWRAP (for GP object)"), # Shrinkwarp type name was the same between GP and other object type !
+    ## /!\ Shrinkwarp type name was the same between GP and other object type ! risk and replace risk to match other objects !
+    # ('regex.quoted', "SHRINKWRAP", "GREASE_PENCIL_SHRINKWRAP (for GP object)"),
+    
+    # Keymap terms (not all are listed)
+    ('regex.quoted', "Grease Pencil Stroke Paint Mode", "Grease Pencil Paint Mode"),
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?

--- a/terms.py
+++ b/terms.py
@@ -227,7 +227,7 @@ TERMS_GP3 = [
     # ("_gpencil_", "_greasepencil_"), # /!\ too generic for now: Only for class names, toolsettings are still gpencil ! 
 
     ("regex.sub", r"(bpy\.types\..*(?:M|P)T.*_)gpencil(_)", r"\g<1>greasepencil\g<2>"), # replace gpencil to greasepencil in bpy.types menu and panels
-    # Modifiers
+    # Modifiers with changed name
     ('regex.quoted', "GP_WEIGHT_PROXIMITY", "GREASE_PENCIL_VERTEX_WEIGHT_PROXIMITY"),
     ('regex.quoted', "GP_WEIGHT_ANGLE", "GREASE_PENCIL_VERTEX_WEIGHT_ANGLE"),
     ('regex.quoted', "GP_LINEART", "LINEART"),
@@ -235,6 +235,13 @@ TERMS_GP3 = [
     ## /!\ Shrinkwarp type name was the same between GP and other object type ! risk and replace risk to match other objects !
     # ('regex.quoted', "SHRINKWRAP", "GREASE_PENCIL_SHRINKWRAP (for GP object)"),
     
+    
+    ## modifier filter name (3 most probable names)
+    ("mod.layer", "mod.layer_filter"),
+    ("modifier.layer", "modifier.layer_filter"),
+    ("mod.layer", "mod.layer_filter"),
+    ("m.layer", "m.layer_filter"),
+
     # Keymap terms (not all are listed)
     ('regex.quoted', "Grease Pencil Stroke Paint Mode", "Grease Pencil Paint Mode"),
     ("bpy.ops.gpencil", "bpy.ops.grease_pencil"), # Operator category name
@@ -244,7 +251,7 @@ TERMS_GP3 = [
     ## All at once ?
     ## TODO: add isinstance(*stroke*, bpy.types.GpencilStroke) equivalent
 
-## Modifiers with simple replace
+## Modifiers with simple prefix swap
 modifier_type_names = [
     'LATTICE',
     'BUILD',

--- a/terms.py
+++ b/terms.py
@@ -236,6 +236,7 @@ TERMS_GP3 = [
     
     # Keymap terms (not all are listed)
     ('regex.quoted', "Grease Pencil Stroke Paint Mode", "Grease Pencil Paint Mode"),
+    ("bpy.ops.gpencil", "bpy.ops.grease_pencil"), # Operator category name
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?

--- a/terms.py
+++ b/terms.py
@@ -202,7 +202,6 @@ TERMS_27 = [
 TERMS_GP3 = [
     (".info", ".name"), # Layer name
     ('regex.sub', r"\.co(?!\w)", ".position"),
-
     ("bpy.ops.gpencil.vertex_group_assign()", "bpy.ops.object.vertex_group_assign()"),
     # ("regex.sub", r"bpy\.ops\.object\.mode_set\(mode=('|\")EDIT_GPENCIL(\1)\)", "bpy.ops.object.mode_set(mode=\g<1>EDIT\g<2>)"), # version to match both quotes (not super clear)
     ("bpy.ops.object.mode_set(mode='EDIT_GPENCIL')", "bpy.ops.object.mode_set(mode='EDIT')"), # single quote version
@@ -214,25 +213,59 @@ TERMS_GP3 = [
     ('regex.quoted', "EDIT_GPENCIL", "EDIT_GREASE_PENCIL"), # edit context
     ('regex.quoted', "SCULPT_GPENCIL", "SCULPT_GREASE_PENCIL"), # sculpt context
     ('regex.quoted', "WEIGHT_GPENCIL", "WEIGHT_GREASE_PENCIL"), # weight context
-    ('regex.quoted', "GP_LATTICE", "'GREASE_PENCIL_LATTICE'"), # modifier
-    (".active_frame", ".current_frame([1])"), # sequence of int (number of points to add on each strokes)
-    (".strokes", ".drawing.strokes"),
+    ('regex.quoted', "VERTEX_GPENCIL", "VERTEX_GREASE_PENCIL"), # Vertex paint context
+    (".active_frame", ".current_frame()"),
+    ('regex.sub', r"(?<!drawing)\.strokes", ".drawing.strokes"),
     (".use_cyclic", ".cyclic"),
-    ("strokes.new()", "-> drawing.add_strokes()"),
+    ("strokes.new()", "-> drawing.add_strokes([0])"), # sequence of int: number of points to add on each strokes (GPv2 added a single stroke with 0 points)
     (".use_multiedit", "-> context.scene.tool_settings.use_grease_pencil_multi_frame_editing"), # Not on GP data anymore !
     ("strokes.remove(", "-> drawing.remove_strokes(indices=(0,)) # stroke index list"), # list of stroke index to remove
     # ("regex.sub", r".*(?:points|strokes).update\(\))", r"\1# \2"), # comment lines with points.update() or stroke.update()
-    ("regex.sub", ".*points.update\(\)", ""), # no points update anymore, delete
-    ("regex.sub", ".*strokes.update\(\)", ""), # no strokes update anymore, delete
-
-    ("regex.sub", r"(bpy\.types\..*(?:M|P)T.*_)gpencil(_)", r"\g<1>greasepencil\g<2>"), # replace gpencil to greasepencil in bpy.types menu and panels
-    
+    ("regex.sub", ".*points.update\(\)", ""), # No points update anymore, delete
+    ("regex.sub", ".*strokes.update\(\)", ""), # No strokes update anymore, delete
     # ("_gpencil_", "_greasepencil_"), # /!\ too generic for now: Only for class names, toolsettings are still gpencil ! 
 
+    ("regex.sub", r"(bpy\.types\..*(?:M|P)T.*_)gpencil(_)", r"\g<1>greasepencil\g<2>"), # replace gpencil to greasepencil in bpy.types menu and panels
+    # Modifiers
+    ('regex.quoted', "GP_WEIGHT_PROXIMITY", "GREASE_PENCIL_VERTEX_WEIGHT_PROXIMITY"),
+    ('regex.quoted', "GP_WEIGHT_ANGLE", "GREASE_PENCIL_VERTEX_WEIGHT_ANGLE"),
+    ('regex.quoted', "GP_LINEART", "LINEART"),
+    ('regex.quoted', "GP_THICK", "GREASE_PENCIL_THICKNESS"),
+    # ('regex.quoted', "SHRINKWRAP", "GREASE_PENCIL_SHRINKWRAP (for GP object)"), # Shrinkwarp type name was the same between GP and other object type !
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?
     ## TODO: add isinstance(*stroke*, bpy.types.GpencilStroke) equivalent
+
+## Modifiers with simple replace
+modifier_type_names = [
+    'LATTICE',
+    'NOISE',
+    'TIME',
+    'TEXTURE',
+    'DASH',
+    'ENVELOPE',
+    'LENGTH',
+    'MIRROR',
+    'MULTIPLY',
+    'OUTLINE',
+    'SIMPLIFY',
+    'SUBDIV',
+    'ARMATURE',
+    'HOOK',
+    'OFFSET',
+    'SMOOTH',
+    'COLOR',
+    'OPACITY',
+    'TINT',
+    'ARRAY',
+]
+
+for mod_name in modifier_type_names:
+    TERMS_GP3.append(
+        ('regex.quoted', f"GP_{mod_name}", f"GREASE_PENCIL_{mod_name}")
+    )
+
 
 #terms = str(TERMS).split('\n')
 #for t in terms:

--- a/terms.py
+++ b/terms.py
@@ -217,6 +217,7 @@ TERMS_GP3 = [
     (".active_frame", ".current_frame()"),
     ('regex.sub', r"(?<!drawing)\.strokes", ".drawing.strokes"),
     (".use_cyclic", ".cyclic"),
+    (".matrix_layer", ".matrix_local"), # matrix_layer not is replaced by matrix_local
     ("strokes.new()", "-> drawing.add_strokes([0])"), # sequence of int: number of points to add on each strokes (GPv2 added a single stroke with 0 points)
     (".use_multiedit", "-> context.scene.tool_settings.use_grease_pencil_multi_frame_editing"), # Not on GP data anymore !
     ("strokes.remove(", "-> drawing.remove_strokes(indices=(0,)) # stroke index list"), # list of stroke index to remove
@@ -237,6 +238,7 @@ TERMS_GP3 = [
     # Keymap terms (not all are listed)
     ('regex.quoted', "Grease Pencil Stroke Paint Mode", "Grease Pencil Paint Mode"),
     ("bpy.ops.gpencil", "bpy.ops.grease_pencil"), # Operator category name
+    ("bpy.ops.gpencil", "bpy.ops.grease_pencil"),
 ]
     # ("VIEW3D_MT_gpencil_edit_context_menu", "VIEW3D_MT_greasepencil_edit_context_menu"),
     ## All at once ?
@@ -245,6 +247,7 @@ TERMS_GP3 = [
 ## Modifiers with simple replace
 modifier_type_names = [
     'LATTICE',
+    'BUILD',
     'NOISE',
     'TIME',
     'TEXTURE',

--- a/ui.py
+++ b/ui.py
@@ -46,7 +46,20 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
             box = box.column(align=True)
             row = box.row(align=True)
             row.alignment = 'LEFT'
+
+            ## button to replace
+            # prop = row.operator(
+            #     "text.update_script_jump",
+            #     text="", icon='BACK', emboss=False) # EVENT_LEFT_ARROW
+            # prop.line = int(cline)
+            # prop.cword = str(cword)
+            # prop.csuggestion = str(csuggestion)
+            # prop.replace = True
+
+            # line
             row.label(text="%4d " % cline)
+
+            ## suggestion and 
             prop = row.operator(
                 "text.update_script_jump",
                 text="%s -> %s" % (cword, csuggestion),
@@ -54,7 +67,9 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
             prop.line = int(cline)
             prop.cword = str(cword)
             prop.csuggestion = str(csuggestion)
-            row.label(text="")
+            
+
+            # row.label(text="")
 
 classes = (
     TEXT_PT_show_update_ui,

--- a/ui.py
+++ b/ui.py
@@ -12,21 +12,34 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
 
     def draw(self, context):
         layout = self.layout
+        # layout.label(text='Tools:')
         layout.operator("text.insert_classes")
         row = layout.row(align=True)
 
         row.operator("text.convert_bl_info_to_manifest", text='bl_info to manifest', icon='COPYDOWN')
         row.operator("text.convert_bl_info_to_manifest", text='Create Manifest File', icon='FILE_TICK').write_on_disk = True
 
-        col = layout.column()
+        col = layout.column(align=True)
         settings = context.scene.script_updater_props
         col.label(text='Include Terms:')
         col.prop(settings, 'check_27', text='From Blender 2.7')
         col.prop(settings, 'check_annotation', text='Properties To Annotation')
         col.prop(settings, 'check_gpv3', text='GPv2 to GPv3')
         col.prop(settings, 'check_icons', text='Icon Names')
+
+        col.separator()
+        col.label(text='Updates:')
         
-        layout.operator("text.update_script_button")
+        row = col.row(align=True)
+        row.prop(settings, 'auto_refresh', text='Auto Refresh')
+
+        hint = row.operator("hint.info_note", text='', icon='QUESTION', emboss=False)
+        hint.title = "Updater System Infos"
+        hint.text = "Click on suggestion text to jump on searched term\
+            \nClick on line number to jump and replace immediately (same as Ctrl+ click on text)\
+            \nAuto Refresh: Automatically re-run check after replace (usualy faster and safer)"
+
+        layout.operator("text.update_script_button", icon='FILE_REFRESH')
         
         # wm = bpy.context.window_manager
         if not hasattr(bpy.types.Scene, 'update_script'):
@@ -37,6 +50,10 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
         box = layout.box()
         # items = wm.update_script
         items = context.scene.update_script
+        if not items:
+            box.label(text="No replace suggestion", icon='CHECKMARK')
+            return
+
         for it in items:
             cline = it[0] # Line number
             cname = it[1] # Original line
@@ -48,16 +65,19 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
             row.alignment = 'LEFT'
 
             ## button to replace
-            # prop = row.operator(
-            #     "text.update_script_jump",
-            #     text="", icon='BACK', emboss=False) # EVENT_LEFT_ARROW
-            # prop.line = int(cline)
-            # prop.cword = str(cword)
-            # prop.csuggestion = str(csuggestion)
-            # prop.replace = True
+            prop = row.operator(
+                "text.update_script_jump",
+                text=str(cline),
+                # text="",
+                # icon='BACK',
+                emboss=True) # EVENT_LEFT_ARROW
+            prop.line = int(cline)
+            prop.cword = str(cword)
+            prop.csuggestion = str(csuggestion)
+            prop.replace = True
 
             # line
-            row.label(text="%4d " % cline)
+            # row.label(text="%4d " % cline)
 
             ## suggestion and 
             prop = row.operator(
@@ -71,7 +91,58 @@ class TEXT_PT_show_update_ui(bpy.types.Panel):
 
             # row.label(text="")
 
+def show_message_box(_message = "", _title = "Message Box", _icon = 'INFO'):
+    '''Show message box with element passed as string or list
+    if _message if a list of lists:
+        if sublist have 2 element:
+            considered a label [text, icon]
+        if sublist have 3 element:
+            considered as an operator [ops_id_name, text, icon]
+        if sublist have 4 element:
+            considered as a property [object, propname, text, icon]
+    '''
+
+    def draw(self, context):
+        layout = self.layout
+        for l in _message:
+            if isinstance(l, str):
+                layout.label(text=l)
+            elif len(l) == 2: # label with icon
+                layout.label(text=l[0], icon=l[1])
+            elif len(l) == 3: # ops
+                layout.operator_context = "INVOKE_DEFAULT"
+                layout.operator(l[0], text=l[1], icon=l[2], emboss=False) # <- highligh the entry
+            elif len(l) == 4: # prop
+                row = layout.row(align=True)
+                row.label(text=l[2], icon=l[3])
+                row.prop(l[0], l[1], text='') 
+    
+    if isinstance(_message, str):
+        _message = [_message]
+    bpy.context.window_manager.popup_menu(draw, title = _title, icon = _icon)
+
+class HINT_OT_info_note(bpy.types.Operator):
+    bl_idname = "hint.info_note"
+    bl_label = "Info Note"
+    bl_description = "Info Note"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    text : bpy.props.StringProperty(default='', options={'SKIP_SAVE'})
+    title : bpy.props.StringProperty(default='Help', options={'SKIP_SAVE'})
+    icon : bpy.props.StringProperty(default='INFO', options={'SKIP_SAVE'})
+
+    @classmethod
+    def description(cls, context, properties):
+        return properties.text
+
+    def execute(self, context):
+        ## Split text in list of lines
+        lines = self.text.split('\n')
+        show_message_box(_message=lines, _title=self.title, _icon=self.icon)
+        return {"FINISHED"}
+
 classes = (
+    HINT_OT_info_note,
     TEXT_PT_show_update_ui,
 )
 

--- a/update_check.py
+++ b/update_check.py
@@ -1,9 +1,18 @@
 import re, bpy
 from bpy.props import IntProperty, StringProperty, BoolProperty
+from bpy.types import Context, OperatorProperties
 
 from .fn import current_text
 from .terms import TERMS, TERMS_27, TERMS_ANNOTATIONS, TERMS_GP3
 
+
+class TEXT_PGT_update_script_item(bpy.types.PropertyGroup):
+    line_number : IntProperty(name="Line Number", default=0)
+    line : StringProperty(name="Line", default="")
+    search : StringProperty(name="Search", default="")
+    replace : StringProperty(name="Replace", default="")
+    done : BoolProperty(name="Done", default=False,
+                        description="Show if the term has been replaced")
 
 def check_files(txt) -> list:
     '''Return a list of lists of search-replace match in text:
@@ -87,6 +96,7 @@ class TEXT_OT_update_script_button(bpy.types.Operator):
     """Run Update Script"""
     bl_idname = "text.update_script_button"
     bl_label = "Run Update Script Check"
+    bl_options = {'REGISTER', 'UNDO'}
 
     def execute(self, context):
         filename = bpy.context.space_data.text.filepath
@@ -144,8 +154,8 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
     """Jump to line"""
     bl_idname = "text.update_script_jump"
     bl_label = "Update_script Jump"
-    bl_description = 'Click to set search replace on current word\
-    \nCtrl+Click for Direct replace'
+    bl_description = 'Click to set search replace on current word + suggestion pair\
+    \nCtrl+Click for Ddrect replace and add undo'
 
     line : IntProperty(default=0, options={'HIDDEN'})
     cword : StringProperty(default="", options={'HIDDEN'})
@@ -153,8 +163,16 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
 
     replace : BoolProperty(default=False, options={'SKIP_SAVE'})
 
+    @classmethod
+    def description(cls, context, properties) -> str:
+        if properties.replace:
+            return 'Click to replace current (same as Ctrl + Click on suggestion)'
+        return cls.bl_description
+
     def invoke(self, context, event):
-        self.replace = event.ctrl
+        if not self.replace:
+            # if not forced, check if ctrl is pressed
+            self.replace = event.ctrl
         return self.execute(context)
 
     def execute(self, context):
@@ -170,6 +188,8 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
             if self.replace:
                 bpy.ops.text.replace()
                 bpy.ops.text.jump(line=line)
+                ## add undo step only if replace is done
+                bpy.ops.ed.undo_push(message=f"Replace {cword} by {csuggestion}")
         self.line = -1
 
         return {'FINISHED'}
@@ -197,6 +217,7 @@ class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
 
 
 classes = (
+    TEXT_PGT_update_script_item,
     TEXT_PGT_script_update_checker_settings,
     TEXT_OT_update_script_jump,
     TEXT_OT_update_script_button,

--- a/update_check.py
+++ b/update_check.py
@@ -5,14 +5,15 @@ from bpy.types import Context, OperatorProperties
 from .fn import current_text
 from .terms import TERMS, TERMS_27, TERMS_ANNOTATIONS, TERMS_GP3
 
-
-class TEXT_PGT_update_script_item(bpy.types.PropertyGroup):
-    line_number : IntProperty(name="Line Number", default=0)
-    line : StringProperty(name="Line", default="")
-    search : StringProperty(name="Search", default="")
-    replace : StringProperty(name="Replace", default="")
-    done : BoolProperty(name="Done", default=False,
-                        description="Show if the term has been replaced")
+## Code to use property group instead of list to store search-replace items
+## (would allow to change "done" value, and show what ahs been replaced, but maybe overkill to add now...)
+# class TEXT_PGT_update_script_item(bpy.types.PropertyGroup):
+#     line_number : IntProperty(name="Line Number", default=0)
+#     line : StringProperty(name="Line", default="")
+#     search : StringProperty(name="Search", default="")
+#     replace : StringProperty(name="Replace", default="")
+#     done : BoolProperty(name="Done", default=False,
+#                         description="Show if the term has been replaced")
 
 def check_files(txt) -> list:
     '''Return a list of lists of search-replace match in text:
@@ -188,8 +189,13 @@ class TEXT_OT_update_script_jump(bpy.types.Operator):
             if self.replace:
                 bpy.ops.text.replace()
                 bpy.ops.text.jump(line=line)
-                ## add undo step only if replace is done
+
+                ## add undo step if replace is done and auto_refresh is off
                 bpy.ops.ed.undo_push(message=f"Replace {cword} by {csuggestion}")
+
+                if bpy.context.scene.script_updater_props.auto_refresh:
+                    bpy.ops.text.update_script_button()
+
         self.line = -1
 
         return {'FINISHED'}
@@ -213,11 +219,15 @@ class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
         description='Check icon name\
             \n(Should use the targeted Blender version for the script!)')
 
+    auto_refresh : BoolProperty(
+        name='Auto Refresh', default=True,
+        description='Automatically re-run the script when a replace has been made using operator')
+
     script_name : bpy.props.StringProperty()
 
 
 classes = (
-    TEXT_PGT_update_script_item,
+    # TEXT_PGT_update_script_item, # unused
     TEXT_PGT_script_update_checker_settings,
     TEXT_OT_update_script_jump,
     TEXT_OT_update_script_button,

--- a/update_check.py
+++ b/update_check.py
@@ -5,15 +5,6 @@ from bpy.types import Context, OperatorProperties
 from .fn import current_text
 from .terms import TERMS, TERMS_27, TERMS_ANNOTATIONS, TERMS_GP3
 
-## Code to use property group instead of list to store search-replace items
-## (would allow to change "done" value, and show what ahs been replaced, but maybe overkill to add now...)
-# class TEXT_PGT_update_script_item(bpy.types.PropertyGroup):
-#     line_number : IntProperty(name="Line Number", default=0)
-#     line : StringProperty(name="Line", default="")
-#     search : StringProperty(name="Search", default="")
-#     replace : StringProperty(name="Replace", default="")
-#     done : BoolProperty(name="Done", default=False,
-#                         description="Show if the term has been replaced")
 
 def check_files(txt) -> list:
     '''Return a list of lists of search-replace match in text:
@@ -225,6 +216,17 @@ class TEXT_PGT_script_update_checker_settings(bpy.types.PropertyGroup) :
 
     script_name : bpy.props.StringProperty()
 
+'''
+## Code to use property group instead of list to store search-replace items
+## (would allow to change "done" value, and show what ahs been replaced, but maybe overkill to add now...)
+class TEXT_PGT_update_script_item(bpy.types.PropertyGroup):
+    line_number : IntProperty(name="Line Number", default=0)
+    line : StringProperty(name="Line", default="")
+    search : StringProperty(name="Search", default="")
+    replace : StringProperty(name="Replace", default="")
+    done : BoolProperty(name="Done", default=False,
+                        description="Show if the term has been replaced")
+'''
 
 classes = (
     # TEXT_PGT_update_script_item, # unused


### PR DESCRIPTION
Added auto refresh when using the direct replace (ctrl + click on the search-suggestion pair), allow to work fast by alternating `click` and `ctrl+click`, barely moving the mouse.

+ some other stuff since last PR.
list below

1.9.0

- added: auto-refresh mode, refresh check after a replace. allowing to work way faster, alternating click and ctrl+click without moving mouse.
- added: undo step push when replacing a term when using replace(safer, allow to ctrl+Z if it was not intended)
- added: line number are now a button you can click on to directly jump and replace (same as Ctrl+Click on text)
- added: feedback text when there are no match
- added: Dynamic jump/replace operator descriptions + an _info note_ button to explain how to use on hover/click

1.8.2

- added: GP v2->v3 modifier type strings
- fixed: some error in new GPv3 API propnames